### PR TITLE
fix documentation issues

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 ==============================================================================
-The LLVM Project is under the Apache License v2.0 with LLVM Exceptions:
+The Beman Project is under the Apache License v2.0 with LLVM Exceptions:
 ==============================================================================
 
                                  Apache License
@@ -222,9 +222,9 @@ the License, but only in their entirety and only with respect to the Combined
 Software.
 
 ==============================================================================
-Software from third parties included in the LLVM Project:
+Software from third parties included in the Beman Project:
 ==============================================================================
-The LLVM Project contains third party software which is under different license
+The Beman Project contains third party software which is under different license
 terms. All such code will be identified clearly using at least one of two
 mechanisms:
 1) It will be in a separate directory tree with its own `LICENSE.txt` or

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This project is organized by our [Governance structure](docs/governance.md).
 ---
 
 [Discourse for new joiners](https://discourse.boost.org/t/welcome-to-the-beman-project-discourse-start-here/40): start here
+
 [Welcome to Beman Project Development Discourse](https://discourse.boost.org/t/welcome-to-beman-project-development/3).
 
 ---

--- a/README.md
+++ b/README.md
@@ -12,7 +12,12 @@ This project is organized by our [Governance structure](docs/governance.md).
 
 ---
 
-Questions?  Maybe they have already been answered in our [FAQ](docs/faq.md).
+[Discourse for new joiners](https://discourse.boost.org/t/welcome-to-the-beman-project-discourse-start-here/40): start here
+[Welcome to Beman Project Development Discourse](https://discourse.boost.org/t/welcome-to-beman-project-development/3).
+
+---
+
+Questions?  Maybe they have already been answered in our [FAQ](docs/FAQ.md).
 
 ---
 

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -22,10 +22,6 @@ The Beman Project Leads are responsible for maintaining the Library Acceptance a
 
 Beman Leads are currently: Jeff Garland, Inbal Levi, and David Sankel
 
-Jeff Garland
-David Sankel
-Inbal Levi
-
 ### 3.1.2 Adding and removing Beman Leads
 
 Any member of Beman Project Leads may step down or be replaced when they are no longer able to contribute effectively. The Beman Project Leads can nominate and decide on adding, removing, or replacing members by a majority decision.


### PR DESCRIPTION
The PR fixes most of [issue 15](https://github.com/beman-project/beman/issues/15):

- Change the license to refer to the "Beman Project" instead of the "LLVM Project".
- Fix the link to the FAQ.
- Add links to Discourse.
- Remove duplicated list of Beman Leads.