### PR TITLE
Configure libraries in libraries.json

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,25 +1,85 @@
-
 cmake_minimum_required(VERSION 3.23)
 project(beman LANGUAGES CXX)
 
 include(CTest)
-
 include(FetchContent)
-FetchContent_Declare(
-  example
-  GIT_REPOSITORY https://github.com/beman-org/example.git
-  GIT_TAG        main
+
+option(
+  BEMAN_USE_MAIN_BRANCHES
+  "Instead of using pinned versions of beman libraries, use each from its main branch."
+  OFF
 )
 
-FetchContent_Declare(
-  scn
-  GIT_REPOSITORY https://github.com/eliaskosunen/scnlib
-  GIT_TAG        v2.0.2
+# jsonfile = ./libraries.json
+set(Beman_jsonfile "${CMAKE_CURRENT_LIST_DIR}/libraries.json")
+
+# force CMake to reconfigure if the JSON file changes
+set_property(
+  DIRECTORY "${CMAKE_CURRENT_LIST_DIR}"
+  APPEND
+  PROPERTY
+    CMAKE_CONFIGURE_DEPENDS "${Beman_jsonfile}"
 )
 
-FetchContent_MakeAvailable(
-  example
-  scn
-)
+# Read the JSON file
+file(READ "${Beman_jsonfile}" Beman_rootobj)
+
+# Get the libraries array and store it in Beman_librariesobj
+string(JSON Beman_librariesobj ERROR_VARIABLE Beman_error GET "${Beman_rootobj}" "libraries")
+if (Beman_error)
+  message(FATAL_ERROR "${Beman_error}")
+endif ()
+
+# Get the length of the libraries array
+string(JSON Beman_numlibraries ERROR_VARIABLE Beman_error LENGTH "${Beman_librariesobj}")
+if (Beman_error)
+  message(FATAL_ERROR "${Beman_error}")
+endif ()
+
+# Loop over each library object
+math(EXPR Beman_maxindex "${Beman_numlibraries} - 1")
+foreach  (Beman_index RANGE "${Beman_maxindex}")
+  # libraryobj = libraryobjs[index]
+  string(JSON Beman_libraryobj ERROR_VARIABLE Beman_error GET "${Beman_librariesobj}" "${Beman_index}")
+  if (Beman_error)
+    message(FATAL_ERROR "${Beman_error}")
+  endif ()
+
+  # name = libraryobj["name"]
+  string(JSON Beman_name ERROR_VARIABLE Beman_error GET "${Beman_libraryobj}" "name")
+  if (Beman_error)
+    message(FATAL_ERROR "${Beman_error}")
+  endif ()
+
+  # repo = libraryobj["git_repository"]
+  string(JSON Beman_repo ERROR_VARIABLE Beman_error GET "${Beman_libraryobj}" "git_repository")
+  if (Beman_error)
+    message(FATAL_ERROR "${Beman_error}")
+  endif ()
+
+  # Select the field to use to fetch the library based on the value of
+  # the BEMAN_USE_MAIN_BRANCHES option
+  if (BEMAN_USE_MAIN_BRANCHES)
+    set(Beman_tagfieldkey "default_branch")
+  else ()
+    set(Beman_tagfieldkey "git_tag")
+  endif ()
+
+  # tag = libraryobj[Beman_tagfieldkey]
+  string(JSON Beman_tag ERROR_VARIABLE Beman_error GET "${Beman_libraryobj}" "${Beman_tagfieldkey}")
+  if (Beman_error)
+    message(FATAL_ERROR "${Beman_error}")
+  endif ()
+
+  message(DEBUG "Fetching ${Beman_name} from ${Beman_repo} at ${Beman_tag}")
+  FetchContent_Declare(
+    "${Beman_name}"
+    GIT_REPOSITORY "${Beman_repo}"
+    GIT_TAG        "${Beman_tag}"
+  )
+  list(APPEND Beman_names "${Beman_name}")
+endforeach ()
+
+FetchContent_MakeAvailable(${Beman_names})
 
 add_subdirectory(example)

--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
-# Project Beman
+# The Beman Project
+
+## About
+
+### Mission
 
 The Beman Project’s [mission](docs/missionstatement.md) is to **support the efficient design and adoption of the highest quality C++ standard libraries** through implementation experience, user feedback, and technical expertise.
 
----
+### Community
 
-We have two principle audiances: Library Developers and the C++ community.  We want to allow Library Developers to have a clear path on the road to Standardization.  And we want to make it easy for the C++ community to use these libraries to ensure we have real world usage.
+We have two principle audiences: Library Developers and the C++ community.  We want to allow Library Developers to have a clear path on the road to Standardization.  And we want to make it easy for the C++ community to use these libraries to ensure we have real world usage.
 
----
+### Governance
 
 This project is organized by our [Governance structure](docs/governance.md).
 
----
+### FAQ
 
 [Discourse for new joiners](https://discourse.boost.org/t/welcome-to-the-beman-project-discourse-start-here/40): start here
 
@@ -20,9 +24,10 @@ This project is organized by our [Governance structure](docs/governance.md).
 
 Questions?  Maybe they have already been answered in our [FAQ](docs/FAQ.md).
 
----
+### About the Name
 
 The Beman project is named in memory of Beman Dawes - co-founder of [Boost](https://www.boost.org).
+
 
 ## Getting Started
 
@@ -31,5 +36,58 @@ $ git clone https://github.com/beman-org/beman.git
 $ cd beman
 $ cmake -S . -B build
 $ cmake --build build
-$ ./build/test/beman_test
+$ ctest --test-dir build
 ```
+
+### CMake Configuration Options
+
+#### `BEMAN_USE_MAIN_BRANCHES`
+
+*Type*: BOOL
+
+*Default*: OFF
+
+By default, the CMake workflow in this repo will clone and build all constituent libraries from git refs as specified in `git_tag` fields in `libraries.json`. If you would instead like to get the *latest* of each library, provide `-DBEMAN_USE_MAIN_BRANCHES=ON` when configuring your CMake build. Be aware that `BEMAN_USE_MAIN_BRANCHES=ON` can result in a less stable user experience as some versions of some libraries may not be published or even fully tested yet.
+
+## Adding a Library
+
+Libraries are enumerated in `libraries.json` in this repository. To add a library to The Beman Project, create a pull request adding a new object to the `libraries` field in that JSON file.
+
+### Library Object JSON Schema
+
+### Example
+
+This is an example JSON object representing a Beman Project library:
+
+```json
+{
+  "name": "example",
+  "git_repository": "https://github.com/beman-project/example.git",
+  "git_tag": "375f3e7",
+  "default_branch": "main"
+}
+```
+
+#### `name`
+
+*Type*: String
+
+A *unique*, logical name for the library.
+
+#### `git_repository`
+
+*Type*: String
+
+A URL for cloning the repository containing the library. This URL does not need to be part of the `beman-project` GitHub organization, or even on GitHub as long as the repo is publicly accessible for cloning.
+
+#### `git_tag`
+
+*Type*: String
+
+A git reference (tag, branch, commit, etc.) that contains a known-working version of the provided library. It is recommended to keep this field up-to-date as the library project and its associated paper evolves.
+
+#### `default_branch`
+
+*Type*: String
+
+The default branch of the library repository, such as `main`. This will be used in workflows where users want the *latest* version of every library, regardless of whether the libraries work, either individually or integrated together.

--- a/libraries.json
+++ b/libraries.json
@@ -1,0 +1,16 @@
+{
+  "libraries": [
+    {
+      "name": "example",
+      "git_repository": "https://github.com/beman-project/example.git",
+      "git_tag": "375f3e7",
+      "default_branch": "main"
+    },
+    {
+      "name": "scn",
+      "git_repository": "https://github.com/eliaskosunen/scnlib.git",
+      "git_tag": "v2.0.2",
+      "default_branch": "master"
+    }
+  ]
+}


### PR DESCRIPTION
See the documentation in README.md for usage of `libraries.json`.

Configuring constituent libraries in a JSON file should have many advantages compared to continuing to add more `FetchContent` logic to `CMakeLists.txt`.

- This approach should be generally more accessible for casual users of The Beman Project to discover and edit exactly how libraries are pulled into this project.

- It will be trivial to have a "use the latest" workflow and a "use stable versions" workflow side-by-side with little need to fiddle inside `CMakeLists.txt` files.

- Pulling each library in with the same logic will discourage the addition of special logic for integrating any given library. For instance, some libraries specifying only a main branch and others specifying only a stable tag.

- JSON files should be generally more accessible to various tools. In particular, it should be possible to periodically build and test all constituent libraries from their latest tags and then automatically update the `git_tag` fields in `libraries.json` accordingly.

- When there is package manager support in The Beman Project, it should be possible to use the contents of `libraries.json` when configuring packaging logic, either as a manifest of library project versions or at least as something to cross reference against in packaging automation.