### PR TITLE
Update FILE.COPYRIGHT to latest decision

### DIFF
--- a/docs/beman-standard.md
+++ b/docs/beman-standard.md
@@ -206,9 +206,5 @@ SPDX-License-Identifier: <SPDX License Expression>
 -->
 ```
 
-**[FILE.COPYRIGHT]** RECOMMENDATION: Source code files should include a
+**[FILE.COPYRIGHT]** RECOMMENDATION: Source code files should NOT include a
 copyright notice following the SPDX license identifier.
-
-```C++
-// Copyright (c) 2024 Your Name <your_email@somewhere.org>
-```


### PR DESCRIPTION
Latest decision: `General consensus: Lets not put the copyright notices in the files (and remove them where they’re at) since the GitHub history will include who has touched a file.`.