### PR TITLE
FIX LINK

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,6 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 This directory contains information about how the project works, goals, and community information.
 
-* [Mission Statement](missionstatement.md)
-* Beman Project [structure and governance](governance.md)
+* [Mission Statement](MISSION_STATEMENT.md)
+* Beman Project [structure and governance](GOVERNANCE.md)
 * [Frequently Asked Questions](FAQ.md)


### PR DESCRIPTION
THE LINK IN `docs/README.md` IS BROKEN BECAUSE IT IS NOT capitalized.